### PR TITLE
fix: Authorization flow with PKCE must use url-safe base64 for code challenge

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -131,7 +131,7 @@ export async function sha256(value) {
  * @returns
  */
 export function base64Buffer(buffer) {
-  return btoa(String.fromCharCode.apply(null, new Uint8Array(buffer))); // .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return btoa(String.fromCharCode.apply(null, new Uint8Array(buffer))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 /**

--- a/test/oauth2/ServerMock.js
+++ b/test/oauth2/ServerMock.js
@@ -184,7 +184,7 @@ module.exports.CodeServerMock = {
     const secret = params.get('client_secret');
     const verifier = params.get('code_verifier');
     const verifierSettings = codeChallenges[code];
-    const challenge = verifier && verifierSettings ? crypto.createHash('sha256').update(verifier).digest('base64') : undefined;
+    const challenge = verifier && verifierSettings ? crypto.createHash('sha256').update(verifier).digest('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '') : undefined;
 
     if (params.get('grant_type') !== 'authorization_code') {
       result.set('error', 'invalid_grant');


### PR DESCRIPTION
This fixes Authorization Code flow with PKCE. See [RFC7636: Appendix A](https://datatracker.ietf.org/doc/html/rfc7636#appendix-A) for example implementation and more information.