### PR TITLE
[W-12119152] Error message when missing token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advanced-rest-client/authorization",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@advanced-rest-client/authorization",
   "description": "The UI and logic related to HTTP authorization.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/Oauth2MethodMixin.js
+++ b/src/Oauth2MethodMixin.js
@@ -567,6 +567,9 @@ const mxFunction = (base) => {
           this.accessToken = tokenInfo.accessToken;
           notifyChange(this);
         }
+        if (detail.grantType === 'client_credentials' && !tokenInfo.accessToken) {
+          this.lastErrorMessage = 'Missing access_token in response';
+      }
       } catch (e) {
         const { message = 'Unknown error' } = e;
         this.lastErrorMessage = message;


### PR DESCRIPTION
Bug: Missing token when requesting access token
Fix: Response has no accessToken for client_credentials. Add error message when no token.